### PR TITLE
Py3 C extension port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - "3.5"
     - "3.6"
     - "pypy"
+    - "pypy3.3-5.2-alpha1"
 install:
     - python bootstrap.py
     - bin/buildout

--- a/include/ExtensionClass/ExtensionClass.h
+++ b/include/ExtensionClass/ExtensionClass.h
@@ -19,61 +19,61 @@
   Extension Class Definitions
 
   Implementing base extension classes
-  
+
     A base extension class is implemented in much the same way that an
     extension type is implemented, except:
-  
+
     - The include file, 'ExtensionClass.h', must be included.
- 
+
     - The type structure is declared to be of type
-    'PyExtensionClass', rather than of type 'PyTypeObject'.
- 
+      'PyExtensionClass', rather than of type 'PyTypeObject'.
+
     - The type structure has an additional member that must be defined
-    after the documentation string.  This extra member is a method chain
-    ('PyMethodChain') containing a linked list of method definition
-    ('PyMethodDef') lists.  Method chains can be used to implement
-    method inheritance in C.  Most extensions don't use method chains,
-    but simply define method lists, which are null-terminated arrays
-    of method definitions.  A macro, 'METHOD_CHAIN' is defined in
-    'ExtensionClass.h' that converts a method list to a method chain.
-    (See the example below.)
-  
+      after the documentation string.  This extra member is a method chain
+      ('PyMethodChain') containing a linked list of method definition
+      ('PyMethodDef') lists.  Method chains can be used to implement
+      method inheritance in C.  Most extensions don't use method chains,
+      but simply define method lists, which are null-terminated arrays
+      of method definitions.  A macro, 'METHOD_CHAIN' is defined in
+      'ExtensionClass.h' that converts a method list to a method chain.
+      (See the example below.)
+
     - Module functions that create new instances must be replaced by an
-    '__init__' method that initializes, but does not create storage for
-    instances.
-  
+      '__init__' method that initializes, but does not create storage for
+      instances.
+
     - The extension class must be initialized and exported to the module
-    with::
-  
-        PyExtensionClass_Export(d,"name",type);
-  
-    where 'name' is the module name and 'type' is the extension class
-    type object.
-  
+      with::
+
+          PyExtensionClass_Export(d,"name",type);
+
+      where 'name' is the module name and 'type' is the extension class
+      type object.
+
     Attribute lookup
-  
-    Attribute lookup is performed by calling the base extension class
-    'getattr' operation for the base extension class that includes C
-    data, or for the first base extension class, if none of the base
-    extension classes include C data.  'ExtensionClass.h' defines a
-    macro 'Py_FindAttrString' that can be used to find an object's
-    attributes that are stored in the object's instance dictionary or
-    in the object's class or base classes::
-  
-       v = Py_FindAttrString(self,name);
-  
+
+      Attribute lookup is performed by calling the base extension class
+      'getattr' operation for the base extension class that includes C
+      data, or for the first base extension class, if none of the base
+      extension classes include C data.  'ExtensionClass.h' defines a
+      macro 'Py_FindAttrString' that can be used to find an object's
+      attributes that are stored in the object's instance dictionary or
+      in the object's class or base classes::
+
+         v = Py_FindAttrString(self,name);
+
     In addition, a macro is provided that replaces 'Py_FindMethod'
     calls with logic to perform the same sort of lookup that is
     provided by 'Py_FindAttrString'.
-  
+
     Linking
-  
-    The extension class mechanism was designed to be useful with
-    dynamically linked extension modules.  Modules that implement
-    extension classes do not have to be linked against an extension
-    class library.  The macro 'PyExtensionClass_Export' imports the
-    'ExtensionClass' module and uses objects imported from this module
-    to initialize an extension class with necessary behavior.
+
+      The extension class mechanism was designed to be useful with
+      dynamically linked extension modules.  Modules that implement
+      extension classes do not have to be linked against an extension
+      class library.  The macro 'PyExtensionClass_Export' imports the
+      'ExtensionClass' module and uses objects imported from this module
+      to initialize an extension class with necessary behavior.
 
 */
 
@@ -106,7 +106,7 @@ static struct ExtensionClassCAPIstruct {
 
 
   PyObject *(*EC_findiattrs_)(PyObject *self, char *cname);
-  int (*PyExtensionClass_Export_)(PyObject *dict, char *name, 
+  int (*PyExtensionClass_Export_)(PyObject *dict, char *name,
                                   PyTypeObject *typ);
   PyObject *(*PyECMethod_New_)(PyObject *callable, PyObject *inst);
   PyExtensionClass *ECBaseType_;
@@ -128,7 +128,7 @@ static struct ExtensionClassCAPIstruct {
    lookup methods or attributes that are not managed by the base type
    directly.  The macro is generally used to search for attributes
    after other attribute searches have failed.
-   
+
    Note that in Python 1.4, a getattr operation may be provided that
    uses an object argument. Classes that support this new operation
    should use Py_FindAttr.
@@ -145,7 +145,7 @@ static struct ExtensionClassCAPIstruct {
    lookup methods or attributes that are not managed by the base type
    directly.  The macro is generally used to search for attributes
    after other attribute searches have failed.
-   
+
    Note that in Python 1.4, a getattr operation may be provided that
    uses an object argument. Classes that support this new operation
    should use Py_FindAttr.
@@ -179,9 +179,9 @@ static struct ExtensionClassCAPIstruct {
 
 /* The following macro checks whether an instance is an extension instance: */
 #define PyExtensionInstance_Check(INST) \
-  PyObject_TypeCheck(((PyObject*)(INST))->ob_type, ECExtensionClassType)
+  PyObject_TypeCheck(Py_TYPE(INST), ECExtensionClassType)
 
-#define CHECK_FOR_ERRORS(MESS) 
+#define CHECK_FOR_ERRORS(MESS)
 
 /* The following macro can be used to define an extension base class
    that only provides method and that is used as a pure mix-in class. */
@@ -208,19 +208,17 @@ static PyExtensionClass NAME ## Type = { PyVarObject_HEAD_INIT(NULL, 0) # NAME, 
   PyExtensionClassCAPI->PyECMethod_New_((CALLABLE),(INST))
 
 /* Return the instance that is bound by an extension class method. */
-#define PyECMethod_Self(M) \
-(PyMethod_Check((M)) ? ((PyMethodObject*)(M))->im_self : NULL)
+#define PyECMethod_Self(M) (PyMethod_Check((M)) ? PyMethod_GET_SELF(M) : NULL)
 
 /* Check whether an object has an __of__ method for returning itself
    in the context of it's container. */
-#define has__of__(O) (PyObject_TypeCheck((O)->ob_type, ECExtensionClassType) \
-                      && (O)->ob_type->tp_descr_get != NULL)
+#define has__of__(O) (PyExtensionInstance_Check(O) && Py_TYPE(O)->tp_descr_get != NULL)
 
 /* The following macros are used to check whether an instance
    or a class' instanses have instance dictionaries: */
 #define HasInstDict(O) (_PyObject_GetDictPtr(O) != NULL)
 
-#define ClassHasInstDict(C) ((C)->tp_dictoffset > 0))
+#define ClassHasInstDict(C) ((C)->tp_dictoffset > 0)
 
 /* Get an object's instance dictionary.  Use with caution */
 #define INSTANCE_DICT(inst) (_PyObject_GetDictPtr(O))
@@ -228,7 +226,7 @@ static PyExtensionClass NAME ## Type = { PyVarObject_HEAD_INIT(NULL, 0) # NAME, 
 /* Test whether an ExtensionClass, S, is a subclass of ExtensionClass C. */
 #define ExtensionClassSubclass_Check(S,C) PyType_IsSubtype((S), (C))
 
-/* Test whether an ExtensionClass instance , I, is a subclass of 
+/* Test whether an ExtensionClass instance , I, is a subclass of
    ExtensionClass C. */
 #define ExtensionClassSubclassInstance_Check(I,C) PyObject_TypeCheck((I), (C))
 
@@ -256,9 +254,9 @@ static PyExtensionClass NAME ## Type = { PyVarObject_HEAD_INIT(NULL, 0) # NAME, 
 #undef PyObject_DEL
 
 #define PyMem_DEL(O)                                   \
-  if (((O)->ob_type->tp_flags & Py_TPFLAGS_HAVE_CLASS) \
-      && ((O)->ob_type->tp_free != NULL))              \
-    (O)->ob_type->tp_free((PyObject*)(O));             \
+  if ((Py_TYPE(O)->tp_flags & Py_TPFLAGS_HAVE_CLASS) \
+      && (Py_TYPE(O)->tp_free != NULL))              \
+    Py_TYPE(O)->tp_free((PyObject*)(O));             \
   else                                                 \
     PyObject_FREE((O));
 

--- a/include/ExtensionClass/_compat.h
+++ b/include/ExtensionClass/_compat.h
@@ -1,0 +1,49 @@
+/*****************************************************************************
+
+  Copyright (c) 2012 Zope Foundation and Contributors.
+  All Rights Reserved.
+
+  This software is subject to the provisions of the Zope Public License,
+  Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+  THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+  WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+  FOR A PARTICULAR PURPOSE
+
+ ****************************************************************************/
+
+#ifndef PERSISTENT__COMPAT_H
+#define PERSISTENT__COMPAT_H
+
+#include "Python.h"
+
+#if PY_MAJOR_VERSION >= 3
+#define PY3K
+#endif
+
+#ifdef PY3K
+#define INTERN PyUnicode_InternFromString
+#define INTERN_INPLACE PyUnicode_InternInPlace
+#define NATIVE_CHECK PyUnicode_Check
+#define NATIVE_CHECK_EXACT PyUnicode_CheckExact
+#define NATIVE_FROM_STRING PyUnicode_FromString
+#define NATIVE_FROM_STRING_AND_SIZE PyUnicode_FromStringAndSize
+
+#define INT_FROM_LONG(x) PyLong_FromLong(x)
+#define INT_CHECK(x) PyLong_Check(x)
+#define INT_AS_LONG(x) PyLong_AS_LONG(x)
+
+#else
+#define INTERN PyString_InternFromString
+#define INTERN_INPLACE PyString_InternInPlace
+#define NATIVE_CHECK PyString_Check
+#define NATIVE_CHECK_EXACT PyString_CheckExact
+#define NATIVE_FROM_STRING PyString_FromString
+#define NATIVE_FROM_STRING_AND_SIZE PyString_FromStringAndSize
+
+#define INT_FROM_LONG(x) PyInt_FromLong(x)
+#define INT_CHECK(x) PyInt_Check(x)
+#define INT_AS_LONG(x) PyInt_AS_LONG(x)
+#endif
+
+#endif

--- a/include/ExtensionClass/_compat.h
+++ b/include/ExtensionClass/_compat.h
@@ -33,6 +33,8 @@
 #define INT_CHECK(x) PyLong_Check(x)
 #define INT_AS_LONG(x) PyLong_AS_LONG(x)
 
+#define HAS_TP_DESCR_GET(ob) 1
+
 #else
 #define INTERN PyString_InternFromString
 #define INTERN_INPLACE PyString_InternInPlace
@@ -44,6 +46,8 @@
 #define INT_FROM_LONG(x) PyInt_FromLong(x)
 #define INT_CHECK(x) PyInt_Check(x)
 #define INT_AS_LONG(x) PyInt_AS_LONG(x)
+
+#define HAS_TP_DESCR_GET(ob) PyType_HasFeature(Py_TYPE(ob), Py_TPFLAGS_HAVE_CLASS)
 #endif
 
 #endif

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import platform
-import sys
 
 from setuptools import setup, find_packages, Extension
 
@@ -11,8 +10,7 @@ CHANGES = open('CHANGES.rst').read()
 py_impl = getattr(platform, 'python_implementation', lambda: None)
 is_pypy = py_impl() == 'PyPy'
 is_pure = 'PURE_PYTHON' in os.environ
-py3k = sys.version_info >= (3, )
-if is_pypy or is_pure or py3k:
+if is_pypy or is_pure:
     ext_modules = []
 else:
     ext_modules = [

--- a/src/Persistence/_Persistence.c
+++ b/src/Persistence/_Persistence.c
@@ -94,19 +94,14 @@ static PyObject *
 P_getattr(cPersistentObject *self, PyObject *name)
 {
   PyObject *v=NULL;
-  char *s;
 
-  name = convert_name(name);
-  if (!name)
+  PyObject* as_bytes = convert_name(name);
+  if (!as_bytes)
     return NULL;
 
-#ifdef PY3K
-  s = PyBytes_AS_STRING(name);
-#else
-  s = PyString_AS_STRING(name);
-#endif
+  char *s = PyBytes_AS_STRING(as_bytes);
 
-  if (*s != '_' || unghost_getattr(s))
+  if (s[0] != '_' || unghost_getattr(s))
     {
       if (PER_USE(self))
         {
@@ -117,8 +112,6 @@ P_getattr(cPersistentObject *self, PyObject *name)
     }
   else
     v = Py_FindAttr((PyObject*)self, name);
-
-  Py_DECREF(name);
 
   return v;
 }

--- a/src/Persistence/_Persistence.c
+++ b/src/Persistence/_Persistence.c
@@ -113,6 +113,8 @@ P_getattr(cPersistentObject *self, PyObject *name)
   else
     v = Py_FindAttr((PyObject*)self, name);
 
+  Py_DECREF(as_bytes);
+
   return v;
 }
 

--- a/src/Persistence/__init__.py
+++ b/src/Persistence/__init__.py
@@ -52,7 +52,7 @@ class Persistent(persistent.Persistent, Base):
 
 if 'PURE_PYTHON' not in os.environ:  # pragma no cover
     try:
-        from _Persistence import Persistent  # NOQA
+        from Persistence._Persistence import Persistent  # NOQA
     except ImportError:
         pass
 


### PR DESCRIPTION
This ports the C extension to Python 3, as suggested in #2.

@stephan-hof this addresses your feedback raised in #2. It compiles and passes all tests on all Python versions and all pure/non-pure environments.

I cut a new branch, rebasing this on master to get my persistent mapping metaclass fix in.