### PR TITLE
Update buildout/tox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: python
 sudo: false
 python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
-    - "3.6"
-    - "pypy"
-    - "pypy3.3-5.2-alpha1"
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy
+    - pypy3.3-5.2-alpha1
 install:
     - pip install -U setuptools==33.1.1
     - pip install zc.buildout
     - buildout bootstrap
-    - buildout tox:env=travis install test
+    - buildout
 script:
-    - bin/test-travis -v1
+    - bin/test -v1
 notifications:
     email: false
 cache:

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,17 +2,13 @@
 extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 develop = .
 parts = interpreter test
-installed = .installed-${tox:env}.cfg
 
 [versions]
 Persistence =
 
-[tox]
-env = py27
-
 [interpreter]
 recipe = zc.recipe.egg
-interpreter = ${tox:env}
+interpreter = py
 eggs =
     Persistence
     tox
@@ -20,4 +16,4 @@ eggs =
 [test]
 recipe = zc.recipe.testrunner
 eggs = Persistence
-script = test-${tox:env}
+script = test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,9 @@
-[nosetests]
-nocapture=1
-cover-package=Persistent
-cover-erase=1
-cover-branches=1
-cover-min-percentage=100
-#with-doctest=0
-where=src
+[flake8]
+ignore = C901,N801,N802,N803,N805,N806,N812
+exclude = bootstrap.py
+
+[bdist_wheel]
+universal = 0
+
+[zest.releaser]
+create-wheel = no

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,24 @@
 [tox]
 envlist =
-    py27,py27-pure,py34,py34-pure,py35,py35-pure,py36,py36-pure,pypy,pypy3
+    py27,
+    py27-pure,
+    py34,
+    py34-pure,
+    py35,
+    py35-pure,
+    py36,
+    py36-pure,
+    pypy,
+    pypy3
 
 [testenv]
 commands =
-    {envbindir}/buildout -c {toxinidir}/buildout.cfg tox:env={envname} bootstrap
-    {envbindir}/buildout -c {toxinidir}/buildout.cfg tox:env={envname} install test
-    {toxinidir}/bin/test-{envname}
+    {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} bootstrap
+    {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir}
+    {envbindir}/test -v1
 skip_install = true
 deps =
+    setuptools==33.1.1
     zc.buildout
 
 [testenv:py27-pure]


### PR DESCRIPTION
Same as DateTime, I think this was the last project where we added version 1 of Tres special buildout/tox setup.

Since this project contains a C extension, I've marked wheel support as disabled.