### PR TITLE
Update to persistent >= 4.2.3.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,6 +5,7 @@ parts = interpreter test
 
 [versions]
 Persistence =
+persistent = >= 4.2.3
 
 [interpreter]
 recipe = zc.recipe.egg


### PR DESCRIPTION
There seems to be regression in persistent 4.2.3+ breaking the test when using the C implementation.

The previously used version was pinned to 4.2.2 using Zope/master/versions.cfg.