### PR TITLE
Use Python implementation to be able to use object as ExtensionClassBase

### DIFF
--- a/src/Persistence/__init__.py
+++ b/src/Persistence/__init__.py
@@ -22,10 +22,10 @@ IS_PYPY = getattr(platform, 'python_implementation', lambda: None)() == 'PyPy'
 IS_PURE = 'PURE_PYTHON' in os.environ
 
 CAPI = not (IS_PYPY or IS_PURE)
-if CAPI:
-    # Both of our dependencies need to have working C extensions
-    from ExtensionClass import _ExtensionClass  # NOQA
-    import persistent.cPersistence
+# if CAPI:
+#     # Both of our dependencies need to have working C extensions
+#     from ExtensionClass import _ExtensionClass  # NOQA
+#     import persistent.cPersistence
 
 
 class Persistent(persistent.Persistent, Base):
@@ -50,9 +50,9 @@ class Persistent(persistent.Persistent, Base):
         return oga(self, name)
 
 
-if CAPI:  # pragma no cover
-    # Override the Python implementation with the C one
-    from Persistence._Persistence import Persistent  # NOQA
+# if CAPI:  # pragma no cover
+#     # Override the Python implementation with the C one
+#     from Persistence._Persistence import Persistent  # NOQA
 
 Overridable = Persistent
 


### PR DESCRIPTION
The experiment was abandoned in https://github.com/zopefoundation/Zope/pull/982. Keeping the changes here for the record.