### PR TITLE
Fix GHA PyPy2 build.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.5"
+          - "3.11.0-beta.3"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -140,7 +140,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Build Dependencies
+      - name: Install Build Dependencies (PyPy2)
+        if: >
+           startsWith(matrix.python-version, 'pypy-2.7')
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine "cffi != 1.15.1"
+      - name: Install Build Dependencies (other Python versions)
+        if: >
+           !startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
@@ -153,7 +161,7 @@ jobs:
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
-          pip install .[test]
+          pip install --pre .[test]
 
       - name: Check Persistence build
         run: |
@@ -173,7 +181,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-alpha.5')
+          && !startsWith(matrix.python-version, '3.11.0-beta.3')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -195,7 +203,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.5"
+          - "3.11.0-beta.3"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -247,7 +255,7 @@ jobs:
           # when we ask it to load tests from that directory. This
           # might also save some build time?
           unzip -n dist/Persistence-*whl -d src
-          pip install -U -e .[test]
+          pip install --pre -U -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -37,8 +37,8 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        "${PYBIN}/pip" install --pre -e /io/
+        "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           "${PYBIN}/pip" install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "15807bd13de45b79c7da560a377fe3f22cbc4338"
+commit-id = "4a77536ce8ad583884a6a3106429fc8af3e13224"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add support for Python 3.11 as of (3.11.0b3).
 
 
 3.3 (2022-03-10)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,14 @@ doctests = 1
 ignore =
     .editorconfig
     .meta.toml
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_third_party = six, docutils, pkg_resources
+known_zope =
+known_first_party =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import os
 import platform
 
-from setuptools import setup, find_packages, Extension
+from setuptools import Extension
+from setuptools import find_packages
+from setuptools import setup
+
 
 README = open('README.rst').read()
 CHANGES = open('CHANGES.rst').read()

--- a/src/Persistence/__init__.py
+++ b/src/Persistence/__init__.py
@@ -14,9 +14,11 @@
 import os
 import platform
 
-from ExtensionClass import Base, Base_getattro
 import persistent
+from ExtensionClass import Base
+from ExtensionClass import Base_getattro
 from persistent.persistence import _SPECIAL_NAMES
+
 
 IS_PYPY = getattr(platform, 'python_implementation', lambda: None)() == 'PyPy'
 IS_PURE = int(os.environ.get('PURE_PYTHON', '0'))
@@ -24,8 +26,8 @@ IS_PURE = int(os.environ.get('PURE_PYTHON', '0'))
 CAPI = not (IS_PYPY or IS_PURE)
 if CAPI:  # pragma: no cover
     # Both of our dependencies need to have working C extensions
-    from ExtensionClass import _ExtensionClass  # NOQA
     import persistent.cPersistence
+    from ExtensionClass import _ExtensionClass  # NOQA
 
 
 class Persistent(persistent.Persistent, Base):

--- a/src/Persistence/mapping.py
+++ b/src/Persistence/mapping.py
@@ -14,9 +14,10 @@
 
 from abc import ABCMeta
 
+import six
+
 from ExtensionClass import ExtensionClass
 from persistent.mapping import PersistentMapping as _BasePersistentMapping
-import six
 
 from Persistence import Persistent
 

--- a/src/Persistence/tests/test_persistent.py
+++ b/src/Persistence/tests/test_persistent.py
@@ -13,16 +13,17 @@
 ##############################################################################
 
 import pickle
-from struct import pack
 import time
 import unittest
+from struct import pack
 
-from Persistence import CAPI
-from Persistence import IS_PYPY
-from Persistence import IS_PURE
-from Persistence import Persistent
 from persistent import PickleCache
 from persistent.TimeStamp import TimeStamp
+
+from Persistence import CAPI
+from Persistence import IS_PURE
+from Persistence import IS_PYPY
+from Persistence import Persistent
 
 
 def p64(v):
@@ -235,6 +236,7 @@ class PersistenceTest(unittest.TestCase):
         self.assertEqual(CAPI, not (IS_PYPY or IS_PURE))
         try:
             import persistent.cPersistence  # noqa: F401 unused, needed for Py3
+
             from Persistence import _Persistence
             cPersistent = _Persistence.Persistent
         except ImportError:

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ envlist =
 
 [testenv]
 usedevelop = true
+pip_pre = true
 deps =
     wheel
 setenv =
@@ -47,12 +48,22 @@ commands =
 [testenv:lint]
 basepython = python3
 skip_install = true
-deps =
-    flake8
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
 commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 src setup.py
     check-manifest
     check-python-versions
+deps =
+    check-manifest
+    check-python-versions >= 0.19.1
+    wheel
+    flake8
+    isort
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []


### PR DESCRIPTION
Additionally:

- update to current meta config version
- apply isort rules

Based on https://github.com/zopefoundation/meta/pull/151