### PR TITLE
Update to current meta/config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe
-  CXXFLAGS: -Ofast -pipe
+  CFLAGS: -O3 -pipe
+  CXXFLAGS: -O3 -pipe
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.
@@ -91,6 +91,7 @@ jobs:
     # Sigh. Note that the matrix must be kept in sync
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:
@@ -104,7 +105,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.3"
+          - "3.11.0-rc.2"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -142,18 +143,19 @@ jobs:
 
       - name: Install Build Dependencies (PyPy2)
         if: >
-           startsWith(matrix.python-version, 'pypy-2.7')
+          startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine "cffi != 1.15.1"
       - name: Install Build Dependencies (other Python versions)
         if: >
-           !startsWith(matrix.python-version, 'pypy-2.7')
+          !startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build Persistence
+      - name: Build Persistence (3.11.0-rc.2)
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.2') }}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
@@ -162,6 +164,33 @@ jobs:
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install --pre .[test]
+      - name: Build Persistence (Python 3.10 on MacOS)
+        if: >
+          startsWith(runner.os, 'Mac')
+          && startsWith(matrix.python-version, '3.10')
+        env:
+          _PYTHON_HOST_PLATFORM: macosx-11-x86_64
+        run: |
+          # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
+          # output (pip install uses a random temporary directory, making this difficult).
+          python setup.py build_ext -i
+          python setup.py bdist_wheel
+          # Also install it, so that we get dependencies in the (pip) cache.
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          pip install .[test]
+
+      - name: Build Persistence (all other versions)
+        if: >
+          !startsWith(runner.os, 'Mac')
+          || !startsWith(matrix.python-version, '3.10')
+        run: |
+          # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
+          # output (pip install uses a random temporary directory, making this difficult).
+          python setup.py build_ext -i
+          python setup.py bdist_wheel
+          # Also install it, so that we get dependencies in the (pip) cache.
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          pip install .[test]
 
       - name: Check Persistence build
         run: |
@@ -181,7 +210,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-beta.3')
+          && !startsWith(matrix.python-version, '3.11.0-rc.2')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -203,7 +232,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.3"
+          - "3.11.0-rc.2"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -244,7 +273,8 @@ jobs:
         with:
           name: Persistence-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install Persistence
+      - name: Install Persistence 3.11.0-rc.2
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.2') }}
         run: |
           pip install -U wheel setuptools
           # coverage has a wheel on PyPI for a future python version which is
@@ -256,6 +286,17 @@ jobs:
           # might also save some build time?
           unzip -n dist/Persistence-*whl -d src
           pip install --pre -U -e .[test]
+      - name: Install Persistence
+        if: ${{ !startsWith(matrix.python-version, '3.11.0-rc.2') }}
+        run: |
+          pip install -U wheel setuptools
+          pip install -U coverage
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          unzip -n dist/Persistence-*whl -d src
+          pip install -U -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |
@@ -338,6 +379,7 @@ jobs:
 
   manylinux:
     runs-on: ubuntu-20.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     # We use a regular Python matrix entry to share as much code as possible.
     strategy:
       matrix:

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "4a77536ce8ad583884a6a3106429fc8af3e13224"
+commit-id = "b5df3766ff8923477f3d24729b19504f0c401a2e"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 3.4 (unreleased)
 ----------------
 
-- Add support for Python 3.11 as of (3.11.0b3).
+- Add support for Python 3.11 as of (3.11.0rc2).
+
+- Disable unsafe math optimizations in C code.
+  (`#55 <https://github.com/zopefoundation/ExtensionClass/pull/55>`_)
 
 
 3.3 (2022-03-10)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ envlist =
 
 [testenv]
 usedevelop = true
-pip_pre = true
+pip_pre = py311: true
 deps =
     wheel
 setenv =


### PR DESCRIPTION
No longer use `-Ofast` in `CFLAGS` as is known to break things.  See https://github.com/zopefoundation/meta/pull/155 for reference.