### PR TITLE
Stop testing Python 3.15

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@
 root = true
 
 
-[*]  # For All Files
+[*]
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
     name: linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
         python-version: '3.13'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,6 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
-          - "3.15"
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: macos-latest
@@ -106,7 +105,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
@@ -150,13 +149,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Build Dependencies (3.15)
-        if: matrix.python-version == '3.15'
-        run: |
-          pip install -U pip
-          pip install -U "setuptools >= 78.1.1,< 81" wheel twine
       - name: Install Build Dependencies
-        if: matrix.python-version != '3.15'
         run: |
           pip install -U pip
           pip install -U "setuptools >= 78.1.1,< 81" wheel twine
@@ -197,15 +190,7 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
-      - name: Install Persistence and dependencies (3.15)
-        if: matrix.python-version == '3.15'
-        run: |
-          # Install to collect dependencies into the (pip) cache.
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          pip install --pre .[test]
       - name: Install Persistence and dependencies
-        if: matrix.python-version != '3.15'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install -U pip "setuptools >= 78.1.1,< 81"
@@ -254,7 +239,6 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
-          - "3.15"
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: macos-latest
@@ -262,7 +246,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
@@ -311,23 +295,7 @@ jobs:
         with:
           name: Persistence-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install Persistence ${{ matrix.python-version }}
-        if: matrix.python-version == '3.15'
-        run: |
-          pip install -U wheel "setuptools >= 78.1.1,< 81"
-          # coverage might have a wheel on PyPI for a future python version which is
-          # not ABI compatible with the current one, so build it from sdist:
-          pip install -U --no-binary :all: coverage[toml]
-          # Unzip into src/ so that testrunner can find the .so files
-          # when we ask it to load tests from that directory. This
-          # might also save some build time?
-          ls -l dist/
-          unzip -n dist/*.whl -d src
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          pip install --pre -e .[test]
       - name: Install Persistence
-        if: matrix.python-version != '3.15'
         run: |
           pip install -U wheel "setuptools >= 78.1.1,< 81"
           pip install -U coverage[toml]
@@ -378,7 +346,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
@@ -456,7 +424,7 @@ jobs:
             python-version: "3.13"
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
@@ -528,9 +496,6 @@ jobs:
 
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
-
-      - name: Prevent publishing wheels for unreleased Python versions
-        run: VER=$(echo '3.15' | tr -d .) && ls -al wheelhouse && sudo rm -f wheelhouse/*-cp${VER}*.whl && ls -al wheelhouse
 
   publish:
     name: Publish to PyPI

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -33,7 +33,6 @@ tox_env_map() {
         *"cp312"*) echo 'py312';;
         *"cp313"*) echo 'py313';;
         *"cp314"*) echo 'py314';;
-        *"cp315"*) echo 'py315';;
         *) echo 'py';;
     esac
 }
@@ -45,15 +44,9 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp311/"* ]] || \
        [[ "${PYBIN}" == *"cp312/"* ]] || \
        [[ "${PYBIN}" == *"cp313/"* ]] || \
-       [[ "${PYBIN}" == *"cp314/"* ]] || \
-       [[ "${PYBIN}" == *"cp315/"* ]] ; then
-        if [[ "${PYBIN}" == *"cp315/"* ]] ; then
-            "${PYBIN}/pip" install --pre -e /io/
-            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
-        else
-            "${PYBIN}/pip" install -e /io/
-            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
-        fi
+       [[ "${PYBIN}" == *"cp314/"* ]] ; then
+        "${PYBIN}/pip" install -e /io/
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           ${PYBIN}/pip install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,13 +2,13 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "9fcd3d67"
+commit-id = "24cb1653"
 
 [python]
 with-windows = true
 with-pypy = true
 with-sphinx-doctests = false
-with-future-python = true
+with-future-python = false
 with-macos = false
 with-docs = false
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,10 @@ envlist =
     py312,py312-pure
     py313,py313-pure
     py314,py314-pure
-    py315,py315-pure
     pypy3
     coverage
 
 [testenv]
-pip_pre = py315: true
 deps =
     setuptools >= 78.1.1,< 81
     wheel


### PR DESCRIPTION
It is broken probably because we need a fix in cffi, see https://github.com/zopefoundation/Persistence/actions/runs/19610857054/job/56156444668